### PR TITLE
Feat/postgresql

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@ media
 
 # env
 hellodjango_project/.env
+.env
 
 # Python vEnvironments 
 .hellodj_venv

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Django #
+*.log
+*.pot
+*.pyc
+__pycache__
+db.sqlite3
+media
+
+# env
+hellodjango_project/.env
+
+# Python vEnvironments 
+.hellodj_venv
+
+
+# Visual Studio Code # 
+.vscode/* 
+!.vscode/settings.json 
+!.vscode/tasks.json 
+!.vscode/launch.json 
+!.vscode/extensions.json 
+.history
+
+# Git
+.git
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ media
 
 # env
 hellodjango_project/.env
+.env
 
 # Python vEnvironments 
 .hellodj_venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,7 @@ RUN pip install -r requirements.txt
 
 # Copy project
 COPY . .
+
+# Document port to be exposed (does not actually expose port)
+EXPOSE 8000
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,3 +26,7 @@ COPY . .
 # Document port to be exposed (does not actually expose port)
 EXPOSE 8000
 
+# CMD: Command to be run when running a container created from this image
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod u+x /docker-entrypoint.sh
+CMD ["/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Pull base image
+FROM python:3.10.8-slim-bullseye
+
+# Set environment variables
+ENV PIP_DISABLE_PIP_VERSION_CHECK 1
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# install psycopg2 dependencies
+RUN apt-get update \
+    && apt-get -y install libpq-dev gcc \
+    && pip install psycopg2
+
+
+# Set work directory
+WORKDIR /mycode
+
+# Install dependencies
+COPY ./requirements.txt .
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+
+# Copy project
+COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY . .
 # Document port to be exposed (does not actually expose port)
 EXPOSE 8000
 
+# edit permissions to allow execution of entrypoint script
+RUN chmod +x ./docker-entrypoint.sh
 # CMD: Command to be run when running a container created from this image
-COPY docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod u+x /docker-entrypoint.sh
-CMD ["/docker-entrypoint.sh"]
+#CMD ["/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ services:
   django:
     build: .
     container_name: django
-    command: python3 manage.py runserver 0.0.0.0:8000
+    #command: python3 manage.py runserver 0.0.0.0:8000
+    #entrypoint: docker-entrypoint.sh
     env_file:
       - ./hellodjango_project/.env
     ports:
@@ -22,7 +23,7 @@ services:
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 1m30s
       timeout: 30s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.9"
+
+services:
+  django:
+    build: .
+    container_name: django
+    command: python3 manage.py runserver 0.0.0.0:8000
+    env_file:
+      - ./hellodjango_project/.env
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+# TODO: add volume?
+  db:
+    image: postgres
+    container_name: pgdb
+    environment:
+      - POSTGRES_DB=testdb
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=mysecretpassword
+    ports:
+      - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,7 @@ services:
   db:
     image: postgres
     container_name: pgdb
-    environment:
-      - POSTGRES_DB=testdb
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=mysecretpassword
+    env_file:
+      - .env
     ports:
       - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,12 @@ services:
       - .env
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 1m30s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
 
 volumes:
   dbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,16 @@ services:
       - "8000:8000"
     depends_on:
       - db
-# TODO: add volume?
+
   db:
     image: postgres
+    volumes:
+      - dbdata:/var/lib/postgresql/data
     container_name: pgdb
     env_file:
       - .env
     ports:
       - "5432:5432"
+
+volumes:
+  dbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,7 @@ services:
   django:
     build: .
     container_name: django
-    #command: python3 manage.py runserver 0.0.0.0:8000
-    #entrypoint: docker-entrypoint.sh
+    entrypoint: ./docker-entrypoint.sh
     env_file:
       - ./hellodjango_project/.env
     ports:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Collect static files
+# echo "Collect static files"
+#python3 manage.py collectstatic --noinput
+
+# Apply database migrations
+echo "Apply database migrations"
+python3 manage.py migrate
+
+# Start server
+echo "Starting server"
+python3 manage.py runserver 0.0.0.0:8000

--- a/hellodjango_project/settings.py
+++ b/hellodjango_project/settings.py
@@ -86,7 +86,7 @@ DATABASES = {
        'NAME': 'testdb',                      
        'USER': 'postgres',
        'PASSWORD': os.getenv('DB_PASS'),
-       'HOST': '127.0.0.1',                      
+       'HOST': 'db',                      
        'PORT': '5432',                      
     }
 }

--- a/hellodjango_project/settings.py
+++ b/hellodjango_project/settings.py
@@ -82,8 +82,12 @@ WSGI_APPLICATION = 'hellodjango_project.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+       'ENGINE': 'django.db.backends.postgresql_psycopg2',
+       'NAME': 'testdb',                      
+       'USER': 'postgres',
+       'PASSWORD': os.getenv('DB_PASS'),
+       'HOST': '127.0.0.1',                      
+       'PORT': '5432',                      
     }
 }
 

--- a/hellodjango_project/settings.py
+++ b/hellodjango_project/settings.py
@@ -85,7 +85,7 @@ DATABASES = {
        'ENGINE': 'django.db.backends.postgresql_psycopg2',
        'NAME': 'testdb',                      
        'USER': 'postgres',
-       'PASSWORD': os.getenv('DB_PASS'),
+       'PASSWORD': os.getenv('POSTGRES_PASSWORD'),
        'HOST': 'db',                      
        'PORT': '5432',                      
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ asgiref==3.5.2
 Django==4.1.2
 django-filter==22.1
 djangorestframework==3.14.0
+psycopg2==2.9.5
 python-dotenv==0.21.0
 pytz==2022.5
 sqlparse==0.4.3


### PR DESCRIPTION
## Change database back-end to PostgreSQL + Containerize app for local development

1. Change database back-end to PostgreSQL. 
2. Add Dockerfile to containerize the Rest API Django application

3. Add Docker-Compose file which starts 2 containers (services):
     - 1 service for the Django application
     - 1 service for the PostgreSQL database with a mounted volume for data persistence. 

A custom **healthcheck** is added to ensure database is ready to accept connections before starting the Django app.
Uses **ENTRYPOINT** script to perform database model migration automatically when the Django container is started.